### PR TITLE
fixed an issue in release_feedback to allow different users to re-release the same feedback

### DIFF
--- a/nbgrader/exchange/default/release_feedback.py
+++ b/nbgrader/exchange/default/release_feedback.py
@@ -76,9 +76,11 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
 
             self.log.debug("Unique key is: {}".format(unique_key))
             checksum = notebook_hash(nbfile, unique_key)
-            dest = os.path.join(self.dest_path, "{}.html".format(checksum))
+            dest = os.path.join(self.dest_path, "{}-tmp.html".format(checksum))
 
             self.log.info("Releasing feedback for student '{}' on assignment '{}/{}/{}' ({})".format(
                 student_id, self.coursedir.course_id, self.coursedir.assignment_id, notebook_id, timestamp))
             shutil.copy(html_file, dest)
+            updated_feedback = os.path.join(self.dest_path, "{}.html". format(checksum))
+            shutil.move(dest, updated_feedback)
             self.log.info("Feedback released to: {}".format(dest))

--- a/nbgrader/exchange/default/release_feedback.py
+++ b/nbgrader/exchange/default/release_feedback.py
@@ -81,6 +81,7 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
             self.log.info("Releasing feedback for student '{}' on assignment '{}/{}/{}' ({})".format(
                 student_id, self.coursedir.course_id, self.coursedir.assignment_id, notebook_id, timestamp))
             shutil.copy(html_file, dest)
+            # Copy to temporary location and mv to update atomically.
             updated_feedback = os.path.join(self.dest_path, "{}.html". format(checksum))
             shutil.move(dest, updated_feedback)
             self.log.info("Feedback released to: {}".format(dest))


### PR DESCRIPTION
To fix the issue where groupshared users could not re-release feedback with 'release_feedback', the feedback file gets copied as a new temporary file to exchange, where it gets moved to replace the old feedback. This way chmod in shutil.copy won't cause issues with the new file being unable to overwrite the old feedback created by an another user.