### PR TITLE
Copy integrity changes

### DIFF
--- a/nbgrader/exchange/default/exchange.py
+++ b/nbgrader/exchange/default/exchange.py
@@ -77,31 +77,36 @@ class Exchange(ABCExchange):
         specified by the options coursedir.ignore, coursedir.include
         and coursedir.max_file_size.
         """
-        shutil.copytree(src, dest,
-                        ignore=ignore_patterns(exclude=self.coursedir.ignore,
-                                               include=self.coursedir.include,
-                                               max_file_size=self.coursedir.max_file_size,
-                                               log=self.log))
-        # copytree copies access mode too - so we must add go+rw back to it if
-        # we are in groupshared.
-        if self.coursedir.groupshared:
-            for dirname, _, filenames in os.walk(dest):
-                # dirs become ug+rwx
-                st_mode = os.stat(dirname).st_mode
-                if st_mode & 0o2770 != 0o2770:
-                    try:
-                        os.chmod(dirname, (st_mode|0o2770) & 0o2777)
-                    except PermissionError:
-                        self.log.warning("Could not update permissions of %s to make it groupshared", dirname)
-
-                for filename in filenames:
-                    filename = os.path.join(dirname, filename)
-                    st_mode = os.stat(filename).st_mode
-                    if st_mode & 0o660 != 0o660:
+        try:
+            shutil.copytree(src, dest,
+                            ignore=ignore_patterns(exclude=self.coursedir.ignore,
+                                                   include=self.coursedir.include,
+                                                   max_file_size=self.coursedir.max_file_size,
+                                                   log=self.log))
+        except OSError as err:
+            raise err
+        # Set permissions for copied files, even if some failed to copy
+        finally:
+            # copytree copies access mode too - so we must add go+rw back to it if
+            # we are in groupshared.
+            if self.coursedir.groupshared:
+                for dirname, _, filenames in os.walk(dest):
+                    # dirs become ug+rwx
+                    st_mode = os.stat(dirname).st_mode
+                    if st_mode & 0o2770 != 0o2770:
                         try:
-                            os.chmod(filename, (st_mode|0o660) & 0o777)
+                            os.chmod(dirname, (st_mode|0o2770) & 0o2777)
                         except PermissionError:
-                            self.log.warning("Could not update permissions of %s to make it groupshared", filename)
+                            self.log.warning("Could not update permissions of %s to make it groupshared", dirname)
+
+                    for filename in filenames:
+                        filename = os.path.join(dirname, filename)
+                        st_mode = os.stat(filename).st_mode
+                        if st_mode & 0o660 != 0o660:
+                            try:
+                                os.chmod(filename, (st_mode|0o660) & 0o777)
+                            except PermissionError:
+                                self.log.warning("Could not update permissions of %s to make it groupshared", filename)
 
     def start(self):
         if sys.platform == 'win32':

--- a/nbgrader/nbextensions/assignment_list/assignment_list.js
+++ b/nbgrader/nbextensions/assignment_list/assignment_list.js
@@ -381,6 +381,25 @@ define([
         return container;
     };
 
+    Assignment.prototype.fetch_error = function (data) {
+        var body = $('<div/>').attr('id', 'fetch-message');
+
+        body.append(
+            $('<div/>').append(
+                $('<p/>').text('Assignment not fetched:')
+            )
+        );
+        body.append(
+            $('<pre/>').text(data.value)
+        );
+
+        dialog.modal({
+            title: "Fetch failed",
+            body: body,
+            buttons: { OK: { class : "btn-primary" } }
+        });
+    };
+
     Assignment.prototype.submit_error = function (data) {
         var body = $('<div/>').attr('id', 'submission-message');
 
@@ -395,6 +414,25 @@ define([
 
         dialog.modal({
             title: "Invalid Submission",
+            body: body,
+            buttons: { OK: { class : "btn-primary" } }
+        });
+    };
+
+    Assignment.prototype.fetchfeedback_error = function (data) {
+        var body = $('<div/>').attr('id', 'fetchfeedback-message');
+
+        body.append(
+            $('<div/>').append(
+                $('<p/>').text('Feedback not fetched:')
+            )
+        );
+        body.append(
+            $('<pre/>').text(data.value)
+        );
+
+        dialog.modal({
+            title: "Fetch Feedback failed",
             body: body,
             buttons: { OK: { class : "btn-primary" } }
         });
@@ -417,7 +455,15 @@ define([
                     },
                     type : "POST",
                     dataType : "json",
-                    success : $.proxy(that.on_refresh, that),
+                    success : function (data, status, xhr) {
+                        if (!data.success) {
+                            that.fetch_error(data);
+                            button.text('Fetch');
+                            button.removeAttr('disabled');
+                        } else {
+                            that.on_refresh(data, status, xhr);
+                        }
+                    },
                     error : function (xhr, status, error) {
                         container.empty().text("Error fetching assignment.");
                         utils.log_ajax_error(xhr, status, error);
@@ -479,7 +525,15 @@ define([
                     },
                     type : "POST",
                     dataType : "json",
-                    success : $.proxy(that.on_refresh, that),
+                    success : function (data, status, xhr) {
+                        if (!data.success) {
+                            that.fetchfeedback_error();
+                            button.text('Fetch Feedback');
+                            button.removeAttr('disabled');
+                        } else {
+                            that.on_refresh(data, status, xhr);
+                        }
+                    },
                     error : function (xhr, status, error) {
                         container.empty().text("Error fetching feedback.");
                         utils.log_ajax_error(xhr, status, error);

--- a/nbgrader/server_extensions/assignment_list/handlers.py
+++ b/nbgrader/server_extensions/assignment_list/handlers.py
@@ -307,8 +307,11 @@ class AssignmentActionHandler(BaseAssignmentHandler):
         if action == 'fetch':
             assignment_id = data['assignment_id']
             course_id = data['course_id']
-            self.manager.fetch_assignment(course_id, assignment_id)
-            self.finish(json.dumps(self.manager.list_assignments(course_id=course_id)))
+            output = self.manager.fetch_assignment(course_id, assignment_id)
+            if output["success"]:
+                self.finish(json.dumps(self.manager.list_assignments(course_id=course_id)))
+            else:
+                self.finish(json.dumps(output))
         elif action == 'submit':
             assignment_id = data['assignment_id']
             course_id = data['course_id']
@@ -320,8 +323,11 @@ class AssignmentActionHandler(BaseAssignmentHandler):
         elif action == 'fetch_feedback':
             assignment_id = data['assignment_id']
             course_id = data['course_id']
-            self.manager.fetch_feedback(course_id, assignment_id)
-            self.finish(json.dumps(self.manager.list_assignments(course_id=course_id)))
+            output = self.manager.fetch_feedback(course_id, assignment_id)
+            if output["success"]:
+                self.finish(json.dumps(self.manager.list_assignments(course_id=course_id)))
+            else:
+                self.finish(json.dumps(output))
 
 
 class CourseListHandler(BaseAssignmentHandler):

--- a/src/assignment_list/assignmentlist.ts
+++ b/src/assignment_list/assignmentlist.ts
@@ -247,6 +247,21 @@ class Assignment {
     return container;
   };
 
+  private fetch_error(data: { value: any; }): void {
+
+    const body_title = React.createElement('p', null, 'Assignment not fetched:');
+    const body_content = React.createElement('pre', null, data.value);
+    const body = React.createElement("div", {'id': 'fetch-message'}, [body_title, body_content]);
+
+    showNbGraderDialog({
+      title: "Fetch Failed",
+      body: body,
+      buttons: [Dialog.okButton()]
+    }, true);
+
+
+  };
+
   private submit_error(data: { value: any; }): void {
 
     const body_title = React.createElement('p', null, 'Assignment not submitted:');
@@ -255,6 +270,21 @@ class Assignment {
 
     showNbGraderDialog({
       title: "Invalid Submission",
+      body: body,
+      buttons: [Dialog.okButton()]
+    }, true);
+
+
+  };
+
+  private fetchfeedback_error(data: { value: any; }): void {
+
+    const body_title = React.createElement('p', null, 'Feedback not fetched:');
+    const body_content = React.createElement('pre', null, data.value);
+    const body = React.createElement("div", {'id': 'fetchfeedback-message'}, [body_title, body_content]);
+
+    showNbGraderDialog({
+      title: "Fetch Failed",
       body: body,
       buttons: [Dialog.okButton()]
     }, true);
@@ -271,7 +301,7 @@ class Assignment {
     var that = this;
     if (this.data['status'] === 'released') {
 
-      button.innerText = "fetch";
+      button.innerText = "Fetch";
       button.onclick = async function(){
         button.innerText = 'Fetching...';
         button.setAttribute('disabled', 'disabled');
@@ -282,7 +312,13 @@ class Assignment {
             method: 'POST'
           });
 
-          that.on_refresh(reply);
+          if(!reply.success){
+              that.fetch_error(reply);
+              button.innerText = 'Fetch'
+              button.removeAttribute('disabled')
+            }else{
+              that.on_refresh(reply);
+            }
         } catch (reason) {
           remove_children(container);
           container.innerText = 'Error fetching assignment.';
@@ -335,7 +371,13 @@ class Assignment {
             method: 'POST'
           });
 
-          that.on_refresh(reply);
+          if(!reply.success){
+              that.fetchfeedback_error(reply);
+              button.innerText = 'Fetch Feedback'
+              button.removeAttribute('disabled')
+            }else{
+              that.on_refresh(reply);
+            }
 
         } catch (reason) {
           remove_children(container);

--- a/style/validation_message.css
+++ b/style/validation_message.css
@@ -1,10 +1,14 @@
+#fetch-message p,
 #submission-message p,
+#fetchfeedback-message p,
 #validation-message p {
     margin-bottom: 1em;
     padding-top: 1em;
 }
 
+#fetch-message pre,
 #submission-message pre,
+#fetchfeedback-message pre,
 #validation-message pre {
     border: solid var(--jp-border-color2) 1px;
     padding: 5px;


### PR DESCRIPTION
- https://github.com/AaltoSciComp/nbgrader/commit/b02d45b2380843066a1a97b765e9a7d0b735057c: Adds error messages when `fetch/fetch_feedback` fails
- https://github.com/AaltoSciComp/nbgrader/commit/3799451aa55bafd84a703bb4febae6a2d4f47940: Wraps copying function into `try/except/finally` to ensure that in the event of an error, already copied files have correct permissions
- https://github.com/AaltoSciComp/nbgrader/commit/7fdbae253f35cf96acba3773a183d25eff6d6a0c: Wraps copying function into `try/except` to ensure that even if not all files were copied, `timestamp.txt` is still created and feedback workflow doesn't break later
  - Right now, the student receives a "Submission Error" and no indication that something is submitted. However, files are still copied to the exchange folder.
  - I think it is fine to not prevent any copying (i.e. delete already-copied files if an error is encountered at any point), because if a student sees "Submission Error", they will likely try submitting again, hopefully after the problem is fixed.