### PR TITLE
Continue autograding if some cells are duplicated

### DIFF
--- a/nbgrader/_version.py
+++ b/nbgrader/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 8, 1, "", "")
-__version__ = ".".join(map(str, version_info[:3])) + "".join(version_info[3:])
+version_info = (0, 8, 1, "dev999")
+__version__ = ".".join(map(str, version_info))

--- a/nbgrader/converters/autograde.py
+++ b/nbgrader/converters/autograde.py
@@ -10,6 +10,7 @@ from .base import BaseConverter, NbGraderException
 from ..preprocessors import (
     AssignLatePenalties, ClearOutput, DeduplicateIds, OverwriteCells, SaveAutoGrades,
     Execute, LimitOutput, OverwriteKernelspec, CheckCellMetadata)
+from ..postprocessors import CheckDuplicateFlag
 from ..api import Gradebook, MissingEntry
 from .. import utils
 
@@ -181,7 +182,6 @@ class Autograde(BaseConverter):
             self.exporter.register_preprocessor(pp)
 
     def convert_single_notebook(self, notebook_filename: str) -> None:
-        self.log.info("Sanitizing %s", notebook_filename)
         self._sanitizing = True
         self._init_preprocessors()
         super(Autograde, self).convert_single_notebook(notebook_filename)
@@ -195,3 +195,6 @@ class Autograde(BaseConverter):
                 super(Autograde, self).convert_single_notebook(notebook_filename)
         finally:
             self._sanitizing = True
+
+        self.log.info(f"Post-processing {notebook_filename}")
+        CheckDuplicateFlag(notebook_filename)

--- a/nbgrader/exchange/default/release_feedback.py
+++ b/nbgrader/exchange/default/release_feedback.py
@@ -76,9 +76,12 @@ class ExchangeReleaseFeedback(Exchange, ABCExchangeReleaseFeedback):
 
             self.log.debug("Unique key is: {}".format(unique_key))
             checksum = notebook_hash(nbfile, unique_key)
-            dest = os.path.join(self.dest_path, "{}.html".format(checksum))
+            dest = os.path.join(self.dest_path, "{}-tmp.html".format(checksum))
 
             self.log.info("Releasing feedback for student '{}' on assignment '{}/{}/{}' ({})".format(
                 student_id, self.coursedir.course_id, self.coursedir.assignment_id, notebook_id, timestamp))
             shutil.copy(html_file, dest)
+            # Copy to temporary location and mv to update atomically.
+            updated_feedback = os.path.join(self.dest_path, "{}.html". format(checksum))
+            shutil.move(dest, updated_feedback)
             self.log.info("Feedback released to: {}".format(dest))

--- a/nbgrader/nbextensions/assignment_list/main.js
+++ b/nbgrader/nbextensions/assignment_list/main.js
@@ -6,7 +6,7 @@ define([
 ], function(Jupyter, $, utils, AssignmentList) {
     "use strict";
 
-    var nbgrader_version = "0.8.1";
+    var nbgrader_version = "0.8.1.dev999";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/nbgrader/nbextensions/course_list/main.js
+++ b/nbgrader/nbextensions/course_list/main.js
@@ -6,7 +6,7 @@ define([
 ], function(Jupyter, $, utils, CourseList) {
     "use strict";
 
-    var nbgrader_version = "0.8.1";
+    var nbgrader_version = "0.8.1.dev999";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/nbgrader/nbextensions/validate_assignment/main.js
+++ b/nbgrader/nbextensions/validate_assignment/main.js
@@ -7,7 +7,7 @@ define([
 ], function ($, Jupyter, dialog, utils) {
     "use strict";
 
-    var nbgrader_version = "0.8.1";
+    var nbgrader_version = "0.8.1.dev999";
 
     var ajax = utils.ajax || $.ajax;
     // Notebook v4.3.1 enabled xsrf so use notebooks ajax that includes the

--- a/nbgrader/nbgraderformat/__init__.py
+++ b/nbgrader/nbgraderformat/__init__.py
@@ -4,3 +4,7 @@ from .v3 import read_v3 as read, write_v3 as write
 from .v3 import reads_v3 as reads, writes_v3 as writes
 
 SCHEMA_VERSION = MetadataValidator.schema_version
+# The values should designate an "unimportant" cell, so that they can be used without breaking anything
+SCHEMA_REQUIRED = {3: {"schema_version": 3, "grade": False, "locked": False, "solution": False},
+                   2: {"schema_version": 2, "grade": False, "locked": False, "solution": False},
+                   1: {"schema_version": 1, "grade": False, "locked": False, "solution": False}}

--- a/nbgrader/postprocessors/__init__.py
+++ b/nbgrader/postprocessors/__init__.py
@@ -1,0 +1,6 @@
+from .checkduplicateflag import CheckDuplicateFlag, DuplicateCellError
+
+__all__ = [
+    "CheckDuplicateFlag",
+    "DuplicateCellError"
+]

--- a/nbgrader/postprocessors/checkduplicateflag.py
+++ b/nbgrader/postprocessors/checkduplicateflag.py
@@ -1,0 +1,29 @@
+import nbformat
+from nbformat.notebooknode import NotebookNode
+
+
+class DuplicateCellError(Exception):
+
+    def __init__(self, message):
+        super(DuplicateCellError, self).__init__(message)
+
+
+# This doesn't have to be a class right now, but I'm writing it that way in case extensions are needed later
+class CheckDuplicateFlag:
+
+    def __init__(self, notebook_filename):
+        # Does this have to be the full path
+        with open(notebook_filename, encoding="utf-8") as f:
+            nb = nbformat.read(f, as_version=nbformat.NO_CONVERT)
+        self.postprocess(nb)
+
+    def postprocess(self, nb: NotebookNode):
+        for cell in nb.cells:
+            self.postprocess_cell(cell)
+
+    @staticmethod
+    def postprocess_cell(cell: NotebookNode):
+        if "nbgrader_local" in cell.metadata and "duplicate" in cell.metadata.nbgrader_local:
+            del cell.metadata.nbgrader_local["duplicate"]  # this should work because it is a dict underneath?
+            msg = "Detected cells with same ids"  # TODO
+            raise DuplicateCellError(msg)

--- a/nbgrader/preprocessors/checkcellmetadata.py
+++ b/nbgrader/preprocessors/checkcellmetadata.py
@@ -13,7 +13,8 @@ class CheckCellMetadata(NbGraderPreprocessor):
             MetadataValidator().validate_nb(nb)
         except ValidationError:
             self.log.error(traceback.format_exc())
-            msg = "Notebook failed to validate; the nbgrader metadata may be corrupted."
+            msg = "Notebook failed to validate; the nbgrader metadata may be corrupted " \
+                  "or a cell might have been duplicated."
             self.log.error(msg)
             raise ValidationError(msg)
 

--- a/nbgrader/preprocessors/deduplicateids.py
+++ b/nbgrader/preprocessors/deduplicateids.py
@@ -1,5 +1,6 @@
 from .. import utils
 from . import NbGraderPreprocessor
+from ..nbgraderformat import SCHEMA_REQUIRED
 from nbconvert.exporters.exporter import ResourcesDict
 from nbformat.notebooknode import NotebookNode
 from typing import Tuple
@@ -33,7 +34,11 @@ class DeduplicateIds(NbGraderPreprocessor):
         grade_id = cell.metadata.nbgrader['grade_id']
         if grade_id in self.grade_ids:
             self.log.warning("Cell with id '%s' exists multiple times!", grade_id)
-            cell.metadata.nbgrader = {}
+            # Replace the cell metadata to make it "unimportant"
+            schema_version = cell.metadata.nbgrader["schema_version"]
+            cell.metadata.nbgrader = SCHEMA_REQUIRED[schema_version]
+            # Add information for `CheckDuplicateFlag` to capture
+            cell.metadata["nbgrader_local"] = {"duplicate": True}
         else:
             self.grade_ids.add(grade_id)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nbgrader",
-  "version": "0.8.1",
+  "version": "0.8.1.dev999",
   "description": "nbgrader nodejs dependencies",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "sqlalchemy>=1.4,<2",
     "traitlets<5.7.0",
 ]
-version = "0.8.1"
+version = "0.8.1.dev999"
 
 [project.license]
 file = "LICENSE"

--- a/src/assignment_list/index.ts
+++ b/src/assignment_list/index.ts
@@ -150,7 +150,7 @@ class AssignmentListWidget extends Widget {
   checkNbGraderVersion() {
     var warning = this.node.getElementsByClassName('version_error')[0] as HTMLDivElement;
     warning.hidden=false;
-    requestAPI<any>('nbgrader_version?version='+"0.8.1")
+    requestAPI<any>('nbgrader_version?version='+"0.8.1.dev999")
     .then(response => {
         if (!response['success']) {
           warning.innerText = response['message'];

--- a/src/course_list/index.ts
+++ b/src/course_list/index.ts
@@ -80,7 +80,7 @@ class CourseListWidget extends Widget {
     }
 
     checkNbGraderVersion() {
-        let nbgrader_version = '0.8.1';
+        let nbgrader_version = '0.8.1.dev999';
         requestAPI<any>('nbgrader_version?version='+nbgrader_version)
             .then(response => {
                 if (!response['success']) {

--- a/src/validate_assignment/index.ts
+++ b/src/validate_assignment/index.ts
@@ -23,7 +23,7 @@ import { requestAPI } from './validateassignment';
 
 import { showNbGraderDialog, validate } from '../common/validate';
 
-var nbgrader_version = "0.8.1"; // TODO: hardcoded value
+var nbgrader_version = "0.8.1.dev999"; // TODO: hardcoded value
 
 const PLUGIN_ID = "nbgrader/validate-assignment"
 


### PR DESCRIPTION
Just putting this here to have it in the repo as well. This is not necessarily complete. I can also make this pr towards another dev branch, one that is numbered `dev700` or something instead of `dev999`.

## Changes
- `deduplicateids.py` upon seeing a duplicated id, converts the cell into an "unimportant" cell that nbgrader can ignore, but leaves additional cell metadata under `"nbgrader_local"`.
- Added `checkduplicateflag.py` postprocessor that is called after autograding to allow logging a `DuplicateCellError` after autograding is complete.
- Changed `Converter` base class to catch `DuplicateCellError`s for each notebook, instead of each assignment.
- Changed error message in `checkcellmetadata.py` to give more informative message (i.e. when validating).


## Long Explanation

Currently, encountering multiple cells with the same `grade_id` (which cell duplication results in) leads to nbgrader deleting the content of the nbgrader metadata of one of the cells (I believe the one that occurs the first in the notebook). The problem is that the deletion happens like this
```
cell_metadata = {
    "key1": value1,
    "key2": value2,
    "nbgrader": {}
}
```
instead of 
```
cell_metadata = {
    "key1": value1,
    "key2": value2
}
```
This then creates a problem in `CheckCellMetadata`, which sees the `"nbgrader"` dictionary being empty and interprets that as corrupted metadata.

Thus, the initial idea is to delete the `"nbgrader"` dictionary completely. The problem is that we will have no idea that something might have gone wrong, like a potential duplication. 

Another complication is that we cannot take much action in the preprocessing stage in order to not interrupt the autograding of the rest of the assignment (for a given person). 

Thus, I decided to change the cell into one that `nbgrader` can ignore (without deleting the basic metadata to differentiate it from other cells, this part might not be too necessary), and add additional metadata under `"nbgrader_local"` that we can detect later in post-processing.

```
cell_metadata = {
    "key1": value1,
    "key2": value2,
    # Unimportant cell
    "nbgrader": {"solution": False, "grade":False, "locked": False}
    "nbgrader_local": {"duplicate": True}
}
```
This `"duplicate"` flag can be incorporated into `"nbgrader"` dictionary as well, but that would require changing the schema in `nbgraderformat`, so it might create future merging headaches unless upstreamed.

With this change, autograding can continue without any problems and `duplicate` flags can be detected when each notebook is graded. `CheckDuplicateFlag` just looks if there is a flag added in `DeduplicateIds`, and if so, removes it and raises an error for `Converter` to log.

One significant change is that the general catching of errors during autograding happens on an assignment level, see `converters/base.py::convert_notebooks`. In order to not skip the rest of the assignment upon encountering a duplication error, I added a second `try/except` chunk inside the `for` loop over notebooks that only catches `DuplicateCellError`.

The changes under `nbgraderformat` are so that the required metadata for "unimportant" cells are not hard-coded into `DeduplicateIds`, so that it will be easier to update if the format ever changes.