### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/test-docs-python-nbextensions.yml
+++ b/.github/workflows/test-docs-python-nbextensions.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   test_nbgrader:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 30
 
     env:
       # NOTE: UTF-8 content may be interpreted as ascii and causes errors

--- a/nbgrader/docs/source/configuration/jupyterhub_config.rst
+++ b/nbgrader/docs/source/configuration/jupyterhub_config.rst
@@ -15,7 +15,7 @@ Using nbgrader with JupyterHub
     :doc:`/user_guide/philosophy`
         More details on how the nbgrader hierarchy is structured.
 
-    `JupyterHub Documentation <https://jupyterhub.readthedocs.io/en/latest/getting-started/index.html>`_
+    `JupyterHub Documentation <https://jupyterhub.readthedocs.io/en/stable>`_
         Detailed documentation describing how JupyterHub works, which is very
         much required reading if you want to integrate the formgrader with
         JupyterHub.

--- a/tasks.py
+++ b/tasks.py
@@ -78,6 +78,10 @@ def _run_tests(mark, skip, junitxml, paralell=False):
 
 
 def _run_ts_test():
+    # Prevent announcement pop-up from interfering with labextension tests
+    # This should probably be in Playwright config, but not sure how to do it yet
+    run('jupyter labextension disable "@jupyterlab/apputils-extension:announcements"')
+
     cmd = ['npx', 'playwright', 'test', '--retries=3']
     run(" ".join(cmd))
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2118,12 +2118,12 @@ caniuse-lite@^1.0.30001349:
   integrity sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g==
 
 canvas@^2.6.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.9.1.tgz#58ec841cba36cef0675bc7a74ebd1561f0b476b0"
-  integrity sha512-vSQti1uG/2gjv3x6QLOZw7TctfufaerTWbVe+NSduHxxLGB+qf3kFgQ6n66DSnuoINtVUjrLLIK2R+lxrBG07A==
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-2.11.0.tgz#7f0c3e9ae94cf469269b5d3a7963a7f3a9936434"
+  integrity sha512-bdTjFexjKJEwtIo0oRx8eD4G2yWoUOXP9lj279jmQ2zMnTQhT8C3512OKz3s+ZOaQlLbE7TuVvRDYDB3Llyy5g==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.0"
-    nan "^2.15.0"
+    nan "^2.17.0"
     simple-get "^3.0.3"
 
 caseless@~0.12.0:
@@ -5073,10 +5073,10 @@ mv@2.1.1:
     ncp "~2.0.0"
     rimraf "~2.4.0"
 
-nan@^2.15.0:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.16.0.tgz#664f43e45460fb98faf00edca0bb0d7b8dce7916"
-  integrity sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==
+nan@^2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.17.0.tgz#c0150a2368a182f033e9aa5195ec76ea41a199cb"
+  integrity sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==
 
 nanoid@^3.1.23, nanoid@^3.3.4:
   version "3.3.4"


### PR DESCRIPTION
There are four problems with the tests right now, all also present in upstream.

1- (DONE) Labextension-ui tests fail due to the JupyterLab [announcements](https://jupyterlab.readthedocs.io/en/stable/user/announcements.html) pop-up. The simple solution is to disable the extension causing it. Ideally this should be in playwright config and doesn't interfere with users own settings, but I wasn't sure how to do that. So I just do it in the python script that calls the tests.
 - This means that if you run the tests locally, the "state" of your computer is changed because the announcement extension is disabled. This is pretty minor though so I think it is okay.
 -  One weird thing is that running the playwright tests in debug mode works fine. So I suspect something like increasing the size of the window enough to remove the popup from important ui elements might also be a band-aid fix.

2- (DONE) The SDist/check-release errors are (most likely, I am pretty sure but I didn't look too carefully yet) caused by something along the JupyterLab chain requesting `node-canvas` pinned to a version that doesn't have a build for the node version used in testing. Then the package manager tries to build the package itself and fails due to missing `pangocairo`. 
  - ~~I don't know what is the best fix yet, but something as simple as fixing the node version should work.~~
  - A better idea is to update the `node-canvas` version. JupyterLab repo itself had this [issue](https://github.com/jupyterlab/jupyterlab/pull/13722) at one point and this is probably what they did too. I'll take a look when I can.

3- (DONE) A link in docs needs to be corrected.

4- (DONE) Some tests take too long for the current timeout setting.